### PR TITLE
feat/참여자 목록과 강퇴기능 추가 구현 (초기 구현)

### DIFF
--- a/src/main/java/com/ll/FlexGym/domain/ChatMessage/entity/ChatMessage.java
+++ b/src/main/java/com/ll/FlexGym/domain/ChatMessage/entity/ChatMessage.java
@@ -12,6 +12,8 @@ import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import org.springframework.util.Assert;
 
+import java.util.List;
+
 import static jakarta.persistence.EnumType.STRING;
 import static jakarta.persistence.FetchType.LAZY;
 import static lombok.AccessLevel.PROTECTED;
@@ -55,5 +57,9 @@ public class ChatMessage extends BaseEntity {
                 .build();
 
         return chatMessage;
+    }
+
+    public void removeChatMessages(String content){
+        this.content = content;
     }
 }

--- a/src/main/java/com/ll/FlexGym/domain/ChatRoom/controller/ChatRoomController.java
+++ b/src/main/java/com/ll/FlexGym/domain/ChatRoom/controller/ChatRoomController.java
@@ -22,6 +22,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+import static com.ll.FlexGym.domain.ChatMember.entity.ChatMemberType.KICKED;
 import static com.ll.FlexGym.domain.ChatMessage.dto.response.SignalType.*;
 import static com.ll.FlexGym.domain.ChatMessage.entity.ChatMessageType.ENTER;
 
@@ -130,6 +131,7 @@ public class ChatRoomController {
 
         model.addAttribute("chatMemberList", chatMemberList);
         model.addAttribute("chatRoom", chatRoom);
+        model.addAttribute("KICKED", KICKED);
         return "usr/chat/memberList";
     }
 }

--- a/src/main/resources/templates/usr/chat/memberList.html
+++ b/src/main/resources/templates/usr/chat/memberList.html
@@ -24,7 +24,7 @@
       </tr>
       </thead>
       <tbody>
-      <tr th:each="chatMember, loop : ${chatMemberList}">
+      <tr th:each="chatMember, loop : ${chatMemberList}" th:if="${chatMember.type != KICKED}">
         <td th:text="${chatMember.member.username}"></td>
         <td th:text="${#temporals.format(chatMember.createDate, 'yyyy/MM/dd hh:mm')}"></td>
         <td>


### PR DESCRIPTION
- [ ] 강퇴된 참여자 목록에서 안나오도록
- [ ] 강퇴된 참여자의 메시지는 "강퇴된 사용자의 메시지입니다." 라는 문구로 대체
- [ ] stomp를 활용하여 실시간 강퇴

---
현재 강퇴된 사용자는 DB에서 삭제 안해주고 있습니다. 도원님이 type을 추가해주셔서 KICKED된 멤버는 다시 방에 들어가지 못하도록 하기 위해서입니다.

실시간 강퇴는 아직 미구현 상태입니다.

